### PR TITLE
Boards collection & choosing an option card to discard upon robot destruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/**
 *.iml
 .DS_Store
+npp.workspace

--- a/both/board.js.coffee
+++ b/both/board.js.coffee
@@ -10,6 +10,7 @@ class @Board
     @max_player = max_player
     @height = height
     @width = width
+    @board_type = "beginner"
 
     for y in [0..@height-1]
       for x in [0..@width-1]

--- a/both/board_box.js.coffee
+++ b/both/board_box.js.coffee
@@ -17,7 +17,7 @@ class @BoardBox
   @cache = []
   @test_board_id = @CATALOG.length
 
-  @getBoard: (boardId) ->
+  @getBoard: (boardId) ->  
     if !boardId? || boardId < 0 || boardId >= @CATALOG.length
       if boardId == @test_board_id
         return @getTestBoard()
@@ -44,6 +44,7 @@ class @BoardBox
   @boards:
     default: () ->
       board = new Board('default',1)
+      board.board_type = "beginner"
       board.length = 'short'
       board.addRallyArea('cross')
       board.addStartArea('simple')
@@ -80,6 +81,7 @@ class @BoardBox
       return board
     checkmate: () ->
       board = new Board('checkmate',5,8)
+      board.board_type = "beginner"
       board.length = 'short'
       board.addRallyArea('chess')
       board.addStartArea('simple')
@@ -88,6 +90,7 @@ class @BoardBox
       return board
     bloodbath_chess: () ->
       board = new Board('bloodbath_chess',2,4)
+      board.board_type = "beginner"
       board.length = 'medium'
       board.addRallyArea('chess')
       board.addStartArea('simple')
@@ -98,6 +101,7 @@ class @BoardBox
       return board
     whirlwind_tour: () ->
       board = new Board('whirlwind_tour',5,8)
+      board.board_type = "expert"
       board.length = 'medium'
       board.addRallyArea('maelstrom')
       board.addStartArea('simple')
@@ -107,6 +111,7 @@ class @BoardBox
       return board
     oddest_sea: () ->
       board = new Board('oddest_sea',5,8,12,28)
+      board.board_type = "expert"
       board.length = 'long'
       board.addRallyArea('vault',0,0,180)
       board.addRallyArea('maelstrom',0,12)
@@ -118,6 +123,7 @@ class @BoardBox
       return board
     dizzy_dash: () ->
       board = new Board('dizzy_dash',2,8)
+      board.board_type = "beginner"
       board.length = 'short'
       board.addRallyArea('spin_zone')
       board.addStartArea('roller')
@@ -127,6 +133,7 @@ class @BoardBox
       return board
     twister: () ->
       board = new Board('twister',5,8)
+      board.board_type = "beginner"
       board.length = 'medium'
       board.addRallyArea('spin_zone')
       board.addStartArea('roller')
@@ -137,6 +144,7 @@ class @BoardBox
       return board
     island_hop: () ->
       board = new Board('island_hop',2,8)
+      board.board_type = "beginner"
       board.length = 'medium'
       board.addRallyArea('island')
       board.addStartArea('simple')
@@ -146,6 +154,7 @@ class @BoardBox
       return board
     death_trap: () ->
       board = new Board('death_trap',2,4)
+      board.board_type = "beginner"
       board.length = 'short'
       board.addRallyArea('island')
       board.addStartArea('simple')
@@ -155,6 +164,7 @@ class @BoardBox
       return board
     around_the_world: () ->
       board = new Board('around_the_world',5,8,12,28)
+      board.board_type = "beginner"
       board.length = 'long'
       board.addRallyArea('island',0,0,180)
       board.addRallyArea('spin_zone',0,12,90)
@@ -165,6 +175,7 @@ class @BoardBox
       return board
     island_king: () ->
       board = new Board('island_king',2,8)
+      board.board_type = "expert"
       board.length = 'short'
       board.addRallyArea('island',0,0,180)
       board.addStartArea('simple')
@@ -174,6 +185,7 @@ class @BoardBox
       return board
     risky_exchange: () ->
       board = new Board('risky_exchange',2,8)
+      board.board_type = "beginner"
       board.length = 'medium'
       board.addRallyArea 'exchange'
       board.addStartArea 'roller'
@@ -183,6 +195,7 @@ class @BoardBox
       return board
     chop_shop_challenge: () ->
       board = new Board('chop_shop_challenge',2,4)
+      board.board_type = "beginner"
       board.length = 'medium'
       board.addRallyArea('chop_shop',0,0,180)
       board.addStartArea('simple')
@@ -193,6 +206,7 @@ class @BoardBox
       return board
     pilgrimage: () ->
       board = new Board('pilgrimage',2,8,12,28)
+      board.board_type = "beginner"
       board.length = 'long'
       board.addRallyArea 'cross'
       board.addRallyArea 'exchange',0,12,180
@@ -211,6 +225,7 @@ class @BoardBox
       return board
     robot_stew: () ->
       board = new Board('robot_stew',2,4)
+      board.board_type = "expert"
       board.length = 'medium'
       board.addRallyArea('chop_shop')
       board.addStartArea('roller')
@@ -220,6 +235,7 @@ class @BoardBox
       return board
     vault_assault: () ->
       board = new Board('vault_assault',2,4)
+      board.board_type = "expert"
       board.length = 'short'
       board.addRallyArea('vault',0,0,270)
       board.addStartArea('roller')
@@ -229,6 +245,7 @@ class @BoardBox
       return board
     lost_bearings: () ->
       board = new Board('lost_bearings',2,4)
+      board.board_type = "expert"
       board.length = 'medium'
       board.addRallyArea 'cross',0,0,180
       board.addStartArea 'simple'
@@ -238,6 +255,7 @@ class @BoardBox
       return board
     against_the_grain: () ->
       board = new Board('against_the_grain',2,4,12,28)
+      board.board_type = "expert"
       board.length = 'medium'
       board.addRallyArea 'chop_shop'
       board.addRallyArea 'chess',0,12,90

--- a/both/gamelogic.js
+++ b/both/gamelogic.js
@@ -300,7 +300,7 @@ GameLogic = {
       player.lives--;
       player.needsRespawn=true;
       player.optionalInstantPowerDown=true;
-      //player.optionCards = {};
+      player.optionCards = {};
       Players.update(player._id, player);
       if (player.lives > 0) {
         var game = player.game();

--- a/both/gamelogic.js
+++ b/both/gamelogic.js
@@ -300,7 +300,7 @@ GameLogic = {
       player.lives--;
       player.needsRespawn=true;
       player.optionalInstantPowerDown=true;
-      player.optionCards = {};
+      //player.optionCards = {};
       Players.update(player._id, player);
       if (player.lives > 0) {
         var game = player.game();

--- a/both/gamestate.js
+++ b/both/gamestate.js
@@ -19,7 +19,8 @@ GameState = {
   },
   RESPAWN_PHASE: {
     CHOOSE_POSITION: "choose position",
-    CHOOSE_DIRECTION: "choose direction"
+    CHOOSE_DIRECTION: "choose direction",
+    CHOOSE_OPTION_CARD: "choose option card to remove"
   }
 };
 
@@ -115,9 +116,28 @@ GameState = {
       var nextPhase;
       var x = player.start.x;
       var y = player.start.y;
-      if (game.isPlayerOnTile(x,y)) {
+      
+      var optioncard_cnt = 0;
+      for(var i in player.optionCards)
+      {
+        if(player.optionCards[i] == true)
+            optioncard_cnt++;
+      }
+      
+      if (game.isPlayerOnTile(x,y))
+      {
         nextPhase = GameState.RESPAWN_PHASE.CHOOSE_POSITION;
-      } else {
+      }
+      
+      if(optioncard_cnt > 1 && !game.isPlayerOnTile(x, y))
+      {
+        console.log("GameState check");
+        nextPhase = GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD;
+      }
+      else
+      {
+        player.optionCards = {};
+        Players.update(player._id, player);
         GameLogic.respawnPlayerAtPos(player,x,y);
         nextPhase = GameState.RESPAWN_PHASE.CHOOSE_DIRECTION;
       }
@@ -344,10 +364,31 @@ GameState = {
         case GameState.RESPAWN_PHASE.CHOOSE_DIRECTION:
           prepareChooseRespawnDirection(game);
           break;
+        case GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD:
+          prepareChooseOptionCard(game);
+        break;
       }
     }, _NEXT_PHASE_DELAY);
   };
 
+  function prepareChooseOptionCard(game)
+  {
+    var player = Players.findOne(game.respawnPlayerId);
+    var selectOptions = [];
+    var x = player.start.x;
+    var y = player.start.y;
+    for (var dx = -1; dx<=1; ++dx) {
+      for (var dy = -1; dy<=1; dy++)  {
+        if (!game.isPlayerOnTile(x+dx,y+dy) && game.board().getTile(x+dx,y+dy).type !== Tile.VOID) {
+          selectOptions.push({x:x+dx, y:y+dy});
+        }
+      }
+    }
+    Games.update(game._id, {$set: {
+      selectOptions: selectOptions,
+      respawnUserId: player.userId
+    }});
+  }
 
   function prepareChooseRespawnPosition(game) {
     var player = Players.findOne(game.respawnPlayerId);

--- a/both/gamestate.js
+++ b/both/gamestate.js
@@ -19,8 +19,7 @@ GameState = {
   },
   RESPAWN_PHASE: {
     CHOOSE_POSITION: "choose position",
-    CHOOSE_DIRECTION: "choose direction",
-    CHOOSE_OPTION_CARD: "choose option card to remove"
+    CHOOSE_DIRECTION: "choose direction"
   }
 };
 
@@ -116,28 +115,9 @@ GameState = {
       var nextPhase;
       var x = player.start.x;
       var y = player.start.y;
-      
-      var optioncard_cnt = 0;
-      for(var i in player.optionCards)
-      {
-        if(player.optionCards[i] == true)
-            optioncard_cnt++;
-      }
-      
-      if (game.isPlayerOnTile(x,y))
-      {
+      if (game.isPlayerOnTile(x,y)) {
         nextPhase = GameState.RESPAWN_PHASE.CHOOSE_POSITION;
-      }
-      
-      if(optioncard_cnt > 1 && !game.isPlayerOnTile(x, y))
-      {
-        console.log("GameState check");
-        nextPhase = GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD;
-      }
-      else
-      {
-        player.optionCards = {};
-        Players.update(player._id, player);
+      } else {
         GameLogic.respawnPlayerAtPos(player,x,y);
         nextPhase = GameState.RESPAWN_PHASE.CHOOSE_DIRECTION;
       }
@@ -364,31 +344,10 @@ GameState = {
         case GameState.RESPAWN_PHASE.CHOOSE_DIRECTION:
           prepareChooseRespawnDirection(game);
           break;
-        case GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD:
-          prepareChooseOptionCard(game);
-        break;
       }
     }, _NEXT_PHASE_DELAY);
   };
 
-  function prepareChooseOptionCard(game)
-  {
-    var player = Players.findOne(game.respawnPlayerId);
-    var selectOptions = [];
-    var x = player.start.x;
-    var y = player.start.y;
-    for (var dx = -1; dx<=1; ++dx) {
-      for (var dy = -1; dy<=1; dy++)  {
-        if (!game.isPlayerOnTile(x+dx,y+dy) && game.board().getTile(x+dx,y+dy).type !== Tile.VOID) {
-          selectOptions.push({x:x+dx, y:y+dy});
-        }
-      }
-    }
-    Games.update(game._id, {$set: {
-      selectOptions: selectOptions,
-      respawnUserId: player.userId
-    }});
-  }
 
   function prepareChooseRespawnPosition(game) {
     var player = Players.findOne(game.respawnPlayerId);

--- a/client/views/board/board.js
+++ b/client/views/board/board.js
@@ -358,6 +358,22 @@ Template.board.events({
   }
 });
 
+Template.optioncard.events({
+    'click .option-card': function(e)
+    {
+        var player = Players.findOne({_id: this.player_id});
+        var game = player.game();
+        console.log("Click: " + game.gamePhase + ", " + game.respawnPhase);
+        if(game.gamePhase == GameState.PHASE.RESPAWN && game.respawnPhase == GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD)
+        {
+            Meteor.call("selectOptionCard", game._id, $(e.target).html(), function(error){
+                if(error)
+                    alert(error.reason);
+            });
+        }
+    }
+});
+
 Template.share.helpers({
   shareData: function() {
     return {

--- a/client/views/board/board.js
+++ b/client/views/board/board.js
@@ -358,22 +358,6 @@ Template.board.events({
   }
 });
 
-Template.optioncard.events({
-    'click .option-card': function(e)
-    {
-        var player = Players.findOne({_id: this.player_id});
-        var game = player.game();
-        console.log("Click: " + game.gamePhase + ", " + game.respawnPhase);
-        if(game.gamePhase == GameState.PHASE.RESPAWN && game.respawnPhase == GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD)
-        {
-            Meteor.call("selectOptionCard", game._id, $(e.target).html(), function(error){
-                if(error)
-                    alert(error.reason);
-            });
-        }
-    }
-});
-
 Template.share.helpers({
   shareData: function() {
     return {

--- a/client/views/cards/cards.jade
+++ b/client/views/cards/cards.jade
@@ -36,7 +36,8 @@ template(name="cards")
         h6
           | Option cards
         each activeOptionCards
-          +optioncard
+          .option-card(title=desc)
+            = name
     if showPlayButton
       if poweredDown
         a.btn.btn-warning.powerBtn #{ownPowerStateName}
@@ -88,11 +89,9 @@ template(name="playerStatus")
       h6
         | Option cards
       each activeOptionCards
-        +optioncard
+        .option-card(title=desc)
+          = name
 
-template(name='optioncard')
-  .option-card(title=desc)
-    = name
 
 template(name="card")
   if emptyCard

--- a/client/views/cards/cards.jade
+++ b/client/views/cards/cards.jade
@@ -36,8 +36,7 @@ template(name="cards")
         h6
           | Option cards
         each activeOptionCards
-          .option-card(title=desc)
-            = name
+          +optioncard
     if showPlayButton
       if poweredDown
         a.btn.btn-warning.powerBtn #{ownPowerStateName}
@@ -89,9 +88,11 @@ template(name="playerStatus")
       h6
         | Option cards
       each activeOptionCards
-        .option-card(title=desc)
-          = name
+        +optioncard
 
+template(name='optioncard')
+  .option-card(title=desc)
+    = name
 
 template(name="card")
   if emptyCard

--- a/client/views/cards/cards.js
+++ b/client/views/cards/cards.js
@@ -103,6 +103,11 @@ Template.cards.helpers({
               return "Choose direction";
             else
               return "Waiting for destroyed bots to reenter";
+          case GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD:
+            if(this.game.respawnUserId === Meteor.userId())
+                return "Choose Option card to discard";
+            else
+                return "Waiting for destroyed bots to reenter";
         }
         break;
     }
@@ -235,10 +240,12 @@ Template.playerStatus.helpers({
   },
   activeOptionCards: function() {
     var r = [];
+    var player = getPlayer();
     Object.keys(this.optionCards).forEach(function(optionKey) {
       r.push({
         name: CardLogic.getOptionTitle(optionKey),
-        desc: CardLogic.getOptionDesc(optionKey)
+        desc: CardLogic.getOptionDesc(optionKey),
+        player_id: player._id
       });
     });
     return r;

--- a/client/views/cards/cards.js
+++ b/client/views/cards/cards.js
@@ -103,11 +103,6 @@ Template.cards.helpers({
               return "Choose direction";
             else
               return "Waiting for destroyed bots to reenter";
-          case GameState.RESPAWN_PHASE.CHOOSE_OPTION_CARD:
-            if(this.game.respawnUserId === Meteor.userId())
-                return "Choose Option card to discard";
-            else
-                return "Waiting for destroyed bots to reenter";
         }
         break;
     }
@@ -240,12 +235,10 @@ Template.playerStatus.helpers({
   },
   activeOptionCards: function() {
     var r = [];
-    var player = getPlayer();
     Object.keys(this.optionCards).forEach(function(optionKey) {
       r.push({
         name: CardLogic.getOptionTitle(optionKey),
-        desc: CardLogic.getOptionDesc(optionKey),
-        player_id: player._id
+        desc: CardLogic.getOptionDesc(optionKey)
       });
     });
     return r;

--- a/collections/boards.js
+++ b/collections/boards.js
@@ -1,0 +1,18 @@
+Boards = new Meteor.Collection('boards', {
+  transform: function (doc) {
+    var newInstance = Object.create(Board);
+    return  _.extend(newInstance, doc);
+  }
+});
+
+Boards.allow({
+  insert: function(userId, doc) {
+    return false;
+  },
+  update: function(userId, doc) {
+    return false;
+  },
+  remove: function(userId, doc) {
+    return false;
+  }
+});

--- a/collections/players.js
+++ b/collections/players.js
@@ -165,24 +165,8 @@ var player = {
     Deck.update({gameId: gameId}, {$set: {optionCards: optionCards}});
   },
   discardOptionCard: function(name) {
-    name = name.toLowerCase();
     var gameId = this.game()._id;
-    console.log("Deleting " + name);
-    
-    delete this.optionCards[name];
-    
-    /*var optionCards = {};
-    
-    for(var i in this.optionCards)
-    {
-        console.log(i);
-        if(i != name)
-            optionCards[i] = true;
-    }
-    
-    this.optionCards = optionCards;*/
-    
-    console.log(this.optionCards);
+    delete optionCards.name;
     var discarded = Deck.findOne({gameId: gameId}).discardedOptionCards;
     discarded.push(CardLogic.getOptionId(name));
     Deck.update({gameId: gameId}, {$set: {discardedOptionCards: discarded}});

--- a/collections/players.js
+++ b/collections/players.js
@@ -165,8 +165,24 @@ var player = {
     Deck.update({gameId: gameId}, {$set: {optionCards: optionCards}});
   },
   discardOptionCard: function(name) {
+    name = name.toLowerCase();
     var gameId = this.game()._id;
-    delete optionCards.name;
+    console.log("Deleting " + name);
+    
+    delete this.optionCards[name];
+    
+    /*var optionCards = {};
+    
+    for(var i in this.optionCards)
+    {
+        console.log(i);
+        if(i != name)
+            optionCards[i] = true;
+    }
+    
+    this.optionCards = optionCards;*/
+    
+    console.log(this.optionCards);
     var discarded = Deck.findOne({gameId: gameId}).discardedOptionCards;
     discarded.push(CardLogic.getOptionId(name));
     Deck.update({gameId: gameId}, {$set: {discardedOptionCards: discarded}});

--- a/server/Debug.js
+++ b/server/Debug.js
@@ -1,0 +1,21 @@
+//This startup is used to add all the existing boards to the Boards collection
+Meteor.startup(function()
+{
+    for(var i in BoardBox.CATALOG)
+    {
+        var board_name = BoardBox.CATALOG[i];
+        var board_id = BoardBox.getBoardId(board_name);
+        var board = BoardBox.getBoard(board_id);
+        
+        if(board != undefined && board != null)
+        {
+            if(Boards.findOne({board_id: board_id}) == null)
+            {
+                console.log("Adding " + board_name + " to Boards collection");
+                board.board_id = board_id;
+                board.owner = "System";
+                Boards.insert(board);
+            }
+        }
+    }
+});

--- a/server/methods.js
+++ b/server/methods.js
@@ -209,18 +209,6 @@ Meteor.methods({
     player.chat('reentered the race', direction);
     GameState.nextGamePhase(game);
   },
-  selectOptionCard: function(gameId, optionCard)
-  {
-    console.log("Discarding something...");
-    var game = Games.findOne(gameId);
-    var player = Players.findOne({gameId: gameId, userId: Meteor.userId()});
-    player.discardOptionCard(optionCard);
-    Players.update(player._id, player);
-    console.log("Discarding " + optionCard);
-    player.chat('chose to discard ' + optionCard, '');
-    GameLogic.respawnPlayerAtPos(player,player.start.x,player.start.y);
-    game.nextRespawnPhase(GameState.RESPAWN_PHASE.CHOOSE_DIRECTION);
-  },
   togglePowerDown: function(gameId) {
      var player = Players.findOne({gameId: gameId, userId: Meteor.userId()});
      return player.togglePowerDown();

--- a/server/methods.js
+++ b/server/methods.js
@@ -209,6 +209,18 @@ Meteor.methods({
     player.chat('reentered the race', direction);
     GameState.nextGamePhase(game);
   },
+  selectOptionCard: function(gameId, optionCard)
+  {
+    console.log("Discarding something...");
+    var game = Games.findOne(gameId);
+    var player = Players.findOne({gameId: gameId, userId: Meteor.userId()});
+    player.discardOptionCard(optionCard);
+    Players.update(player._id, player);
+    console.log("Discarding " + optionCard);
+    player.chat('chose to discard ' + optionCard, '');
+    GameLogic.respawnPlayerAtPos(player,player.start.x,player.start.y);
+    game.nextRespawnPhase(GameState.RESPAWN_PHASE.CHOOSE_DIRECTION);
+  },
   togglePowerDown: function(gameId) {
      var player = Players.findOne({gameId: gameId, userId: Meteor.userId()});
      return player.togglePowerDown();


### PR DESCRIPTION
Commit "Board collection":
Added a board collection and a startup function that will add all the
existing boards (which are statically written) into it.
The reason for the board collection is custom boards, which will come
later along with a board editor

Commit "Lose on option card on death": (Yeah I know, spelled it wrong)
The rules state: "A destroyed robot immediately loses an Option card of
the player’s choice". Currently, all option cards are lost, this fixes
it and allows the player to choose which card that should be destroyed
(If the player has 2 or more option cards).

I was a bit to hasty with the commands and accidently reverted the second commit.
I ran the command again to revert the revert, so it should be fine.
